### PR TITLE
NodeJs dependency bumps

### DIFF
--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -55,8 +55,8 @@ def test_refresh_token_expired_token():
     now = time.time()
     raw_token = jwt.encode(
         {
-            'iat': now,
-            'exp': now-1,
+            'iat': now-1,
+            'exp': now-2,
             'azp': 'test',
         },
         'secret',
@@ -73,7 +73,7 @@ def test_refresh_token_expired_token():
 
 def test_refresh_token_valid_token():
     now = time.time()
-    in_token = {'iat': now, 'exp': now + 5, 'azp': 'test', }
+    in_token = {'iat': now-1, 'exp': now + 5, 'azp': 'test', }
     raw_token = jwt.encode(
         in_token,
         'secret',

--- a/λ@E/package.json
+++ b/λ@E/package.json
@@ -1,13 +1,13 @@
 {
   "name": "lambdaatedge",
   "dependencies": {
-    "jsonwebtoken": "^8.3.0"
+    "jsonwebtoken": "^9.0.0"
   },
   "dependenciesCOMMENT": {
     "aws-sdk": "also required, but is already installed on λ@E. Also, this boost our size up beyond the allowed 1MB."
   },
   "devDependencies": {
-    "mocha": "^6.2.0",
-    "rewire": "^4.0.1"
+    "mocha": "^10.2.0",
+    "rewire": "^6.0.0"
   }
 }


### PR DESCRIPTION
- Fix python tests by making sure tokens are from the past
- Update node dependencies


both node (mocha_ and python (pytest) test pass