### PR TITLE
Bugfix: IAM protected paths not reachable because of Sigv4 mismatch

### DIFF
--- a/templates/example.py
+++ b/templates/example.py
@@ -197,6 +197,7 @@ template.add_resource(route53.RecordSetType(
     HostedZoneName=Join('', [Ref(param_hosted_zone_name), '.']),
     Name=domain_name,
     Type='A',
+    Condition=use_cert_cond,
 ))
 template.add_resource(route53.RecordSetType(
     "DomainAAAA",
@@ -208,6 +209,7 @@ template.add_resource(route53.RecordSetType(
     HostedZoneName=Join('', [Ref(param_hosted_zone_name), '.']),
     Name=domain_name,
     Type='AAAA',
+    Condition=use_cert_cond,
 ))
 
 cfnutils.output.write_template_to_file(template)


### PR DESCRIPTION
**Summary:**
Fixes the bug where IAM protected paths were not reachable (`/generate_ci`) because of Sigv4 mismatch on `Host` header, even when accessing with correct IAM permissions.

After a little bit of digging, we found out that we still need the `ApiDomain` Resource when bringing/creating our own CloudFront. But we configure `ApiDomain` as "regional" instead of "edge".  This way we get an endpoint that is correctly configured to let the Sigv4 matching happen correctly with the correct "Host" header.

**New params:**
* `Headers` with default value: "Authorization,Host", which are needed for Sigv4 matching.
* `RegionalAcmCertArn` gives the possibility to give an already created regional cert to the regional API Domain. When left empty, a regional cert will be created instead

--

Also a small condition bugfix in the example.py template.