### PR TITLE
The subject field of grants needs to be a string, not an array.

### DIFF
--- a/src/delegate.py
+++ b/src/delegate.py
@@ -104,18 +104,15 @@ def handler(event, context: LambdaContext) -> dict:
             if not domains.issubset(refresh_token['domains']):
                 return bad_request('', 'domain requested outside refresh_token')
 
-        # Normalize and validate no commas in subject or existing sub chain to avoid join ambiguity
+        # Validate no commas in new subject to avoid future join ambiguity
         if ',' in subject:
             return bad_request('', 'subject contains invalid comma')
 
         existing_sub = refresh_token.get('sub', [])
         if isinstance(existing_sub, str):
-            if ',' in existing_sub:
-                return bad_request('', 'existing sub chain string contains invalid comma')
-            existing_sub = [existing_sub]  # Convert string to single-element list
+            existing_sub = [x.strip() for x in existing_sub.split(',')] # Convert string to list
         elif isinstance(existing_sub, list):
-            if any(',' in s for s in existing_sub if isinstance(s, str)):
-                return bad_request('', 'existing sub chain array contains invalid comma')
+            pass  # Already a list, no change needed
 
         delegate_token = {
             'iat': int(time.time()),

--- a/src/delegate.py
+++ b/src/delegate.py
@@ -122,7 +122,7 @@ def handler(event, context: LambdaContext) -> dict:
             'exp': exp,
             'domains': list(domains),
             'azp': refresh_token['azp'],  # Authorized Party
-            'sub': ', '.join(existing_sub + [subject]),  # sub must be string adhering to jwt spec: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
+            'sub': ','.join(existing_sub + [subject]),  # sub must be string adhering to jwt spec: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
         }
         logger.info({"message": "Issuing JWT", "jwt": delegate_token})
         raw_delegate_token = jwt.encode(

--- a/src/delegate.py
+++ b/src/delegate.py
@@ -104,12 +104,19 @@ def handler(event, context: LambdaContext) -> dict:
             if not domains.issubset(refresh_token['domains']):
                 return bad_request('', 'domain requested outside refresh_token')
 
+        # Validate no commas in subject or existing sub chain to avoid join ambiguity
+        if ',' in subject:
+            return bad_request('', 'subject contains invalid comma')
+        existing_sub = refresh_token.get('sub', [])
+        if any(',' in s for s in existing_sub if isinstance(s, str)):
+            return bad_request('', 'existing sub chain contains invalid comma')
+
         delegate_token = {
             'iat': int(time.time()),
             'exp': exp,
             'domains': list(domains),
             'azp': refresh_token['azp'],  # Authorized Party
-            'sub': refresh_token.get('sub', []) + [subject],  # subject
+            'sub': ', '.join(existing_sub + [subject]),  # sub must be string adhering to jwt spec: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
         }
         logger.info({"message": "Issuing JWT", "jwt": delegate_token})
         raw_delegate_token = jwt.encode(

--- a/src/delegate.py
+++ b/src/delegate.py
@@ -104,12 +104,18 @@ def handler(event, context: LambdaContext) -> dict:
             if not domains.issubset(refresh_token['domains']):
                 return bad_request('', 'domain requested outside refresh_token')
 
-        # Validate no commas in subject or existing sub chain to avoid join ambiguity
+        # Normalize and validate no commas in subject or existing sub chain to avoid join ambiguity
         if ',' in subject:
             return bad_request('', 'subject contains invalid comma')
+
         existing_sub = refresh_token.get('sub', [])
-        if any(',' in s for s in existing_sub if isinstance(s, str)):
-            return bad_request('', 'existing sub chain contains invalid comma')
+        if isinstance(existing_sub, str):
+            if ',' in existing_sub:
+                return bad_request('', 'existing sub chain string contains invalid comma')
+            existing_sub = [existing_sub]  # Convert string to single-element list
+        elif isinstance(existing_sub, list):
+            if any(',' in s for s in existing_sub if isinstance(s, str)):
+                return bad_request('', 'existing sub chain array contains invalid comma')
 
         delegate_token = {
             'iat': int(time.time()),

--- a/src/use_grant.py
+++ b/src/use_grant.py
@@ -20,6 +20,7 @@ def handler(event, context) -> dict:
             raw_grant,
             get_grant_jwt_secret(),
             algorithms=['HS256'],
+            options={'require': [], 'verify_sub': False},  # Disable validation for now until sub field are all strings.
         )
         assert 'exp' in grant
         assert 'azp' in grant


### PR DESCRIPTION
This was always in the jwt specification, but was not enforced in the jwt python library until recently. 
https://github.com/jpadilla/pyjwt/pull/1005

disable verification of the sub field until we're sure new tokens are correct in ~4 months